### PR TITLE
Fix RetroArch URL

### DIFF
--- a/source/apps/games/retroarch/metadata.json
+++ b/source/apps/games/retroarch/metadata.json
@@ -10,7 +10,7 @@
     "proprietary": false,
     "alternate-to": null,
     "urls": {
-        "info": "http://libretro.com",
+        "info": "http://retroarch.com",
         "android-app": "https://play.google.com/store/apps/details?id=com.retroarch",
         "ios-app": null
     },


### PR DESCRIPTION
There is a new RetroArch website over at http://retroarch.com . Gives a bit more information about the frontend, rather than just the libretro organization. This commit updates to use http://retroarch.com rather than http://libretro.com .