### PR TITLE
Fix RetroArch for Artful Aardvark releases

### DIFF
--- a/source/apps/games/retroarch/metadata.json
+++ b/source/apps/games/retroarch/metadata.json
@@ -20,7 +20,8 @@
     ],
     "releases": [
         "xenial",
-        "zesty"
+        "zesty",
+        "artful"
     ],
     "method": "apt",
     "installation": {


### PR DESCRIPTION
RetroArch is available for Artful Aardvark:
https://launchpad.net/~libretro/+archive/ubuntu/stable?field.series_filter=artful